### PR TITLE
Fix(server): Remove duplicate server.listen() call

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -76,7 +76,3 @@ io.on('connection', (socket) => {
 // cron.schedule('*/15 * * * *', () => {
 //     // checkAndSendReminders();
 // });
-
-server.listen(PORT, () => {
-  console.log(`Servidor escuchando en el puerto ${PORT}`);
-});


### PR DESCRIPTION
The server was failing to start on Render due to an `ERR_SERVER_ALREADY_LISTEN` error. This was caused by `server.listen()` being called twice in `server/index.js`.

This commit removes the redundant call, ensuring the server starts correctly.