### PR TITLE
fix: Configure CORS and environment variables for production

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -26,7 +26,7 @@ const server = http.createServer(app);
 // --- Configuración de CORS para Socket.IO ---
 const io = new Server(server, {
     cors: {
-        origin: "http://localhost:5173",
+        origin: process.env.CORS_ALLOWED_ORIGIN || "http://localhost:5173",
         methods: ["GET", "POST", "PUT", "DELETE", "PATCH"] // Añadido PATCH
     }
 });


### PR DESCRIPTION
This commit resolves the final issues preventing the frontend and backend from communicating in a production environment.

Changes include:
- fix(server): Configure Socket.IO CORS to accept requests from the frontend URL via the `CORS_ALLOWED_ORIGIN` environment variable.
- feat(frontend): Use `VITE_SOCKET_URL` environment variable for the Socket.IO connection URL.
- chore: Ensure `server.listen()` is present for the server to start.