### PR TITLE
debug: Add console logs for Vercel environment variables

### DIFF
--- a/frontend/src/components/NotificationProvider.jsx
+++ b/frontend/src/components/NotificationProvider.jsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect, createContext, useContext } from 'react';
 import io from 'socket.io-client';
 
+console.log("Debug: VITE_SOCKET_URL from env is:", import.meta.env.VITE_SOCKET_URL);
 const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || 'http://localhost:5001';
+console.log("Debug: Final SOCKET_URL is:", SOCKET_URL);
 const socket = io(SOCKET_URL);
 
 // 1. Creamos un contexto para las notificaciones


### PR DESCRIPTION
To diagnose why the `VITE_SOCKET_URL` environment variable is not being picked up by the Vercel deployment, this commit adds `console.log` statements to the `NotificationProvider`.

This will print the value of the environment variable as seen by the application in the production environment, allowing for a definitive diagnosis of the issue.