### PR TITLE
refactor(frontend): Consolidate Socket.IO connection

### DIFF
--- a/frontend/src/components/BookingCalendar.jsx
+++ b/frontend/src/components/BookingCalendar.jsx
@@ -1,11 +1,8 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import axios from 'axios';
-import io from 'socket.io-client';
+import { socket } from './NotificationProvider';
 import { format, addMonths, subMonths, startOfMonth, endOfMonth, startOfWeek, endOfWeek, eachDayOfInterval, isSameDay, isToday, isSameMonth } from 'date-fns';
 import { es } from 'date-fns/locale';
-
-const API_URL = 'http://localhost:5001';
-const socket = io(API_URL);
 
 // --- Componente para una celda del calendario ---
 const CalendarCell = ({ day, onDateClick, isSelected, isCurrentMonth }) => {

--- a/frontend/src/components/BookingManager.jsx
+++ b/frontend/src/components/BookingManager.jsx
@@ -1,9 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import axios from 'axios';
-import io from 'socket.io-client';
-
-const API_URL = 'http://localhost:5001';
-const socket = io(API_URL);
+import { socket } from './NotificationProvider';
 
 const BookingManager = () => {
     const [bookings, setBookings] = useState([]);

--- a/frontend/src/components/NotificationProvider.jsx
+++ b/frontend/src/components/NotificationProvider.jsx
@@ -1,10 +1,8 @@
 import React, { useState, useEffect, createContext, useContext } from 'react';
 import io from 'socket.io-client';
 
-console.log("Debug: VITE_SOCKET_URL from env is:", import.meta.env.VITE_SOCKET_URL);
 const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || 'http://localhost:5001';
-console.log("Debug: Final SOCKET_URL is:", SOCKET_URL);
-const socket = io(SOCKET_URL);
+export const socket = io(SOCKET_URL);
 
 // 1. Creamos un contexto para las notificaciones
 const NotificationContext = createContext();


### PR DESCRIPTION
The application was creating multiple, independent Socket.IO connections in different components (`NotificationProvider`, `BookingCalendar`, `BookingManager`). Most of these connections were hardcoded to `localhost:5001`, causing connection errors in the production environment.

This commit refactors the code to use a single, shared Socket.IO instance. The instance is created and configured in `NotificationProvider.jsx` using the `VITE_SOCKET_URL` environment variable, and then exported. Other components now import and use this shared instance.

This ensures that all real-time communication goes through one correctly configured channel and resolves the persistent `ERR_CONNECTION_REFUSED` errors.