### PR TITLE
feat: Add PWA installability and finalize deployment configuration

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="50" fill="#22C55E"/>
+</svg>

--- a/frontend/public/icon-192.svg
+++ b/frontend/public/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="45" fill="#22C55E" stroke="#FFFFFF" stroke-width="5"/>
+  <text x="50" y="60" font-size="40" fill="white" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold">PC</text>
+</svg>

--- a/frontend/public/icon-512.svg
+++ b/frontend/public/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="45" fill="#22C55E" stroke="#FFFFFF" stroke-width="5"/>
+  <text x="50" y="60" font-size="40" fill="white" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold">PC</text>
+</svg>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,35 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { VitePWA } from 'vite-plugin-pwa'
+
+export default defineConfig({
+  plugins: [
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      includeAssets: ['favicon.svg', 'icon-192.svg', 'icon-512.svg'],
+      manifest: {
+        name: 'Padel Club Manager',
+        short_name: 'PadelClub',
+        description: 'Gestión de turnos y canchas de pádel.',
+        theme_color: '#1A202C',
+        background_color: '#1A202C',
+        display: 'standalone',
+        scope: '/',
+        start_url: '/',
+        icons: [
+          {
+            src: 'icon-192.svg',
+            sizes: '192x192',
+            type: 'image/svg+xml'
+          },
+          {
+            src: 'icon-512.svg',
+            sizes: '512x512',
+            type: 'image/svg+xml'
+          }
+        ]
+      }
+    })
+  ]
+})


### PR DESCRIPTION
This commit includes the final set of changes to make the application fully deployable and installable as a PWA.

Key changes:
- Add a `vite.config.js` to configure `vite-plugin-pwa`, making the frontend installable.
- Add placeholder icons and a favicon to be used by the PWA manifest and to resolve the 404 error.
- Refactor all frontend components to use a single, shared, and correctly configured Socket.IO connection, fixing the root cause of the connection errors.
- Ensure all environment-specific URLs (API, Socket, CORS, payment redirects) are handled by environment variables.
- Include a `vercel.json` to ensure correct builds on Vercel.