### PR TITLE
fix: Update Mercado Pago SDK to v2 syntax

### DIFF
--- a/server/config/mercadopago-config.js
+++ b/server/config/mercadopago-config.js
@@ -1,9 +1,9 @@
-const mercadopago = require('mercadopago');
+const { MercadoPagoConfig } = require('mercadopago');
 require('dotenv').config();
 
-// Configure Mercado Pago SDK
-mercadopago.configure({
-  access_token: process.env.MERCADOPAGO_ACCESS_TOKEN,
+// Initialize Mercado Pago SDK v2
+const client = new MercadoPagoConfig({
+  accessToken: process.env.MERCADOPAGO_ACCESS_TOKEN,
 });
 
-module.exports = mercadopago;
+module.exports = client;


### PR DESCRIPTION
The application was failing on Render with a 'TypeError: mercadopago.configure is not a function' because the installed 'mercadopago' library (v2.0.8) uses a new API.

This commit updates the integration to be compatible with the Mercado Pago SDK v2:
- Modifies 'server/config/mercadopago-config.js' to initialize the client using 'new MercadoPagoConfig()'.
- Refactors 'server/controllers/paymentController.js' to use the new class-based approach for creating preferences ('new Preference(client)') and fetching payments ('new Payment(client)').

This resolves the runtime error and aligns the codebase with the current version of the SDK.