### PR TITLE
fix(server): Configure CORS to allow credentials for Socket.IO

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -27,7 +27,8 @@ const startServer = async () => {
       } else {
         callback(new Error('Not allowed by CORS'));
       }
-    }
+    },
+    credentials: true
   };
 
   app.use(cors(corsOptions));
@@ -38,6 +39,7 @@ const startServer = async () => {
     cors: {
       origin: allowedOrigins,
       methods: ["GET", "POST", "PUT", "DELETE"],
+      credentials: true
     },
   });
 


### PR DESCRIPTION
Resolves a CORS error with Socket.IO when connecting from a different origin with credentials.

- Adds `credentials: true` to the Express CORS middleware options to allow credentialed requests.
- Adds `credentials: true` to the Socket.IO CORS configuration to allow the WebSocket connection to be established with credentials.