### PR TITLE
Fix: Correct timezone handling in booking availability

### DIFF
--- a/frontend/src/components/TimeSlotFinder.jsx
+++ b/frontend/src/components/TimeSlotFinder.jsx
@@ -66,8 +66,7 @@ const TimeSlotFinder = () => {
             try {
                 setLoading(true);
                 setError('');
-                const date = new Date(selectedDate);
-                const data = await bookingService.getAvailability(selectedCourt, date.toISOString());
+                const data = await bookingService.getAvailability(selectedCourt, selectedDate);
                 setBookedSlots(data);
             } catch (err) {
                 setError('No se pudo cargar la disponibilidad.');

--- a/server/controllers/bookingController.js
+++ b/server/controllers/bookingController.js
@@ -83,9 +83,11 @@ const getBookingAvailability = async (req, res) => {
     }
 
     try {
-        const [year, month, day] = date.split('T')[0].split('-').map(Number);
-        const startOfDay = new Date(year, month - 1, day, 0, 0, 0, 0);
-        const endOfDay = new Date(year, month - 1, day, 23, 59, 59, 999);
+        const startOfDay = new Date(date);
+        startOfDay.setUTCHours(0, 0, 0, 0);
+
+        const endOfDay = new Date(date);
+        endOfDay.setUTCHours(23, 59, 59, 999);
 
         const bookings = await Booking.find({
             court: courtId,


### PR DESCRIPTION
This commit resolves a timezone bug that caused a 24-hour discrepancy in booking availability.

- In `frontend/src/components/TimeSlotFinder.jsx`, the `selectedDate` is now passed directly to the `getAvailability` service without converting it to an ISO string. This prevents the browser from adding unwanted timezone information.
- In `server/controllers/bookingController.js`, the `getBookingAvailability` function has been updated to interpret the received date in UTC by using `new Date(date)` and `setUTCHours`. This ensures consistent date handling regardless of the server's timezone.